### PR TITLE
support for module path/file based whitelist

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,19 @@ module.exports = function hook (modules, options, onrequire) {
       name = stat.name
       basedir = stat.basedir
 
+      // get the absolute file name of the module being `require`d
+      var absFile = path.join(name, stat.path);
+
+      // get the relative file name (without the extension) of the module being `require`d
+      var relFile = absFile.replace(path.extname(stat.path), '');
+
+      // figure out if the absolute file name is in the whitelist
+      if (modules.indexOf(absFile) !== -1)
+        name = absFile;
+      // figure out if the relative file name is in the whitelist
+      else if (modules.indexOf(relFile) !== -1)
+        name = relFile;
+
       if (modules && modules.indexOf(name) === -1) return exports // abort if module name isn't on whitelist
 
       // figure out if this is the main module file, or a file inside the module

--- a/index.js
+++ b/index.js
@@ -45,17 +45,15 @@ module.exports = function hook (modules, options, onrequire) {
       basedir = stat.basedir
 
       // get the absolute file name of the module being `require`d
-      var absFile = path.join(name, stat.path);
+      var absFile = path.join(name, stat.path)
 
       // get the relative file name (without the extension) of the module being `require`d
-      var relFile = absFile.replace(path.extname(stat.path), '');
+      var relFile = absFile.replace(path.extname(stat.path), '')
 
       // figure out if the absolute file name is in the whitelist
-      if (modules.indexOf(absFile) !== -1)
-        name = absFile;
+      if (modules.indexOf(absFile) !== -1) name = absFile
       // figure out if the relative file name is in the whitelist
-      else if (modules.indexOf(relFile) !== -1)
-        name = relFile;
+      else if (modules.indexOf(relFile) !== -1) name = relFile
 
       if (modules && modules.indexOf(name) === -1) return exports // abort if module name isn't on whitelist
 


### PR DESCRIPTION
This patch should allow users to whitelist module names based on their file paths (absolute and relative both).

Example 

```js
var path = require('path')
var hook = require('require-in-the-middle')

var moduleList = [
	'meta-router', 
	'meta-router/middleware/invokeHandler'
];

hook(moduleList, function (exports, name, basedir) {
  var version = require(path.join(basedir, 'package.json')).version
  console.log('\nloading %s@%s', name, version)
  exports._version = version
  console.log(exports);
  return exports
})

var a = require('meta-router');
var b = require('meta-router/middleware/invokeHandler')
```
### Reference
[meta-router](https://github.com/patrick-steele-idem/meta-router)
[meta-router/middleware/invokeHandler](https://github.com/patrick-steele-idem/meta-router/blob/master/middleware/invokeHandler.js)

