### PR TITLE
Fix mid-circular dependencies

### DIFF
--- a/test/node_modules/mid-circular/bar.js
+++ b/test/node_modules/mid-circular/bar.js
@@ -1,0 +1,3 @@
+var root = require('./')
+
+exports.foo = root.foo + 1

--- a/test/node_modules/mid-circular/foo.js
+++ b/test/node_modules/mid-circular/foo.js
@@ -1,0 +1,4 @@
+var root = require('./')
+var bar = require('./bar')
+
+exports.foo = root.foo + bar.foo + 1

--- a/test/node_modules/mid-circular/index.js
+++ b/test/node_modules/mid-circular/index.js
@@ -1,0 +1,5 @@
+exports.foo = 1
+
+exports.multiCircular = require('./foo').foo
+
+exports.baz = 'buz'

--- a/test/test.js
+++ b/test/test.js
@@ -117,6 +117,23 @@ test('circular', function (t) {
   t.deepEqual(require('./node_modules/circular'), { foo: 1 })
 })
 
+test('mid circular applies to completed module', function (t) {
+  t.plan(2)
+
+  var expected = {
+    foo: 1,
+    multiCircular: 4,
+    baz: 'buz'
+  }
+
+  hook(['mid-circular'], function (exports, name, basedir) {
+    t.deepEqual(exports, expected)
+    return exports
+  })
+
+  t.deepEqual(require('./node_modules/mid-circular'), expected)
+})
+
 test('internal', function (t) {
   t.plan(8)
 


### PR DESCRIPTION
This keeps track of in-progress patches so mid-circular dependencies don't result in the patch function being applied to the partial middle state, blocking the patching of the later completed state. Instead, only the outer state will be patched while inner states will skip patching because it seems there is already an in-progress patch.

cc @watson 