### PR TITLE
chore: update repo links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/opbeat/require-in-the-middle.git"
+    "url": "git+https://github.com/elastic/require-in-the-middle.git"
   },
   "keywords": [
     "require",
@@ -36,9 +36,9 @@
   "author": "Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/opbeat/require-in-the-middle/issues"
+    "url": "https://github.com/elastic/require-in-the-middle/issues"
   },
-  "homepage": "https://github.com/opbeat/require-in-the-middle#readme",
+  "homepage": "https://github.com/elastic/require-in-the-middle#readme",
   "coordinates": [
     55.6779395,
     12.5715844


### PR DESCRIPTION
This repo was moved to a different org recently, but the links in the package.json wasn't updated.