### PR TITLE
chore: change npm badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 Hook into the Node.js `require` function. This allows you to modify
 modules on-the-fly as they are being required.
 
-[![npm](https://nodei.co/npm/require-in-the-middle.png)](https://www.npmjs.com/package/require-in-the-middle)
-
+[![npm](https://img.shields.io/npm/v/require-in-the-middle.svg)](https://www.npmjs.com/package/require-in-the-middle)
 [![Build status](https://travis-ci.org/elastic/require-in-the-middle.svg?branch=master)](https://travis-ci.org/elastic/require-in-the-middle)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)
 


### PR DESCRIPTION
The old badge didn't show the correct dependency numbers, so let's just use a simpler one. As long as it links to the npm page then it's good 😄 