### PR TITLE
feat: add support for sub-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Arguments:
 
 - `modules` &lt;string[]> An optional array of module names to limit which modules
   trigger a call of the `onrequire` callback. If specified, this must be the
-  first argument.
+  first argument. Both regular modules (e.g. `react-dom`) and
+  sub-modules (e.g. `react-dom/server`) can be specified in the array.
 - `options` &lt;Object> An optional object containing fields that change when the
   `onrequire` callback is called. If specified, this must be the second
   argument.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ var parse = require('module-details-from-path')
 
 module.exports = Hook
 
+// 'foo/bar.js' or 'foo/bar/index.js' => 'foo/bar'
+var normalize = /([/\\]index)?(\.js)?$/
+
 function Hook (modules, options, onrequire) {
   if (!(this instanceof Hook)) return new Hook(modules, options, onrequire)
   if (typeof modules === 'function') {
@@ -91,26 +94,37 @@ function Hook (modules, options, onrequire) {
       moduleName = stat.name
       basedir = stat.basedir
 
-      debug('resolved filename to module: %s (request: %s, basedir: %s)', moduleName, request, basedir)
+      var fullModuleName = resolveModuleName(stat)
 
-      if (modules && modules.indexOf(moduleName) === -1) return exports // abort if module name isn't on whitelist
+      debug('resolved filename to module: %s (request: %s, resolved: %s, basedir: %s)', moduleName, request, fullModuleName, basedir)
 
-      // figure out if this is the main module file, or a file inside the module
-      try {
-        var res = resolve.sync(moduleName, { basedir: basedir })
-      } catch (e) {
-        debug('could not resolve module: %s', moduleName)
-        return exports // abort if module could not be resolved (e.g. no main in package.json and no index.js file)
-      }
-      if (res !== filename) {
-        // this is a module-internal file
-        if (options.internals) {
-          // use the module-relative path to the file, prefixed by original module name
-          moduleName = moduleName + path.sep + path.relative(basedir, filename)
-          debug('preparing to process require of internal file: %s', moduleName)
-        } else {
-          debug('ignoring require of non-main module file: %s', res)
-          return exports // abort if not main module file
+      // Ex: require('foo/lib/../bar.js')
+      // moduleName = 'foo'
+      // fullModuleName = 'foo/bar'
+      if (modules && modules.indexOf(moduleName) === -1) {
+        if (modules.indexOf(fullModuleName) === -1) return exports // abort if module name isn't on whitelist
+
+        // if we get to this point, it means that we're requiring a whitelisted sub-module
+        moduleName = fullModuleName
+      } else {
+        // figure out if this is the main module file, or a file inside the module
+        try {
+          var res = resolve.sync(moduleName, { basedir: basedir })
+        } catch (e) {
+          debug('could not resolve module: %s', moduleName)
+          return exports // abort if module could not be resolved (e.g. no main in package.json and no index.js file)
+        }
+
+        if (res !== filename) {
+          // this is a module-internal file
+          if (options.internals) {
+            // use the module-relative path to the file, prefixed by original module name
+            moduleName = moduleName + path.sep + path.relative(basedir, filename)
+            debug('preparing to process require of internal file: %s', moduleName)
+          } else {
+            debug('ignoring require of non-main module file: %s', res)
+            return exports // abort if not main module file
+          }
         }
       }
     }
@@ -137,4 +151,9 @@ Hook.prototype.unhook = function () {
   } else {
     debug('unhook unsuccessful')
   }
+}
+
+function resolveModuleName (stat) {
+  const normalizedPath = path.sep !== '/' ? stat.path.split(path.sep).join('/') : stat.path
+  return path.posix.join(stat.name, normalizedPath).replace(normalize, '')
 }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function Hook (modules, options, onrequire) {
 
     var filename = Module._resolveFilename(request, this)
     var core = filename.indexOf(path.sep) === -1
-    var name, basedir
+    var moduleName, basedir
 
     debug('processing %s module require(\'%s\'): %s', core ? 'core' : 'non-core', request, filename)
 
@@ -81,33 +81,33 @@ function Hook (modules, options, onrequire) {
         debug('ignoring core module not on whitelist: %s', filename)
         return exports // abort if module name isn't on whitelist
       }
-      name = filename
+      moduleName = filename
     } else {
       var stat = parse(filename)
       if (!stat) {
         debug('could not parse filename: %s', filename)
         return exports // abort if filename could not be parsed
       }
-      name = stat.name
+      moduleName = stat.name
       basedir = stat.basedir
 
-      debug('resolved filename to module: %s (request: %s, basedir: %s)', name, request, basedir)
+      debug('resolved filename to module: %s (request: %s, basedir: %s)', moduleName, request, basedir)
 
-      if (modules && modules.indexOf(name) === -1) return exports // abort if module name isn't on whitelist
+      if (modules && modules.indexOf(moduleName) === -1) return exports // abort if module name isn't on whitelist
 
       // figure out if this is the main module file, or a file inside the module
       try {
-        var res = resolve.sync(name, { basedir: basedir })
+        var res = resolve.sync(moduleName, { basedir: basedir })
       } catch (e) {
-        debug('could not resolve module: %s', name)
+        debug('could not resolve module: %s', moduleName)
         return exports // abort if module could not be resolved (e.g. no main in package.json and no index.js file)
       }
       if (res !== filename) {
         // this is a module-internal file
         if (options.internals) {
           // use the module-relative path to the file, prefixed by original module name
-          name = name + path.sep + path.relative(basedir, filename)
-          debug('preparing to process require of internal file: %s', name)
+          moduleName = moduleName + path.sep + path.relative(basedir, filename)
+          debug('preparing to process require of internal file: %s', moduleName)
         } else {
           debug('ignoring require of non-main module file: %s', res)
           return exports // abort if not main module file
@@ -120,11 +120,11 @@ function Hook (modules, options, onrequire) {
       // ensure that the cache entry is assigned a value before calling
       // onrequire, in case calling onrequire requires the same module.
       self.cache[filename] = exports
-      debug('calling require hook: %s', name)
-      self.cache[filename] = onrequire(exports, name, basedir)
+      debug('calling require hook: %s', moduleName)
+      self.cache[filename] = onrequire(exports, moduleName, basedir)
     }
 
-    debug('returning module: %s', name)
+    debug('returning module: %s', moduleName)
     return self.cache[filename]
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tape": "^4.9.0"
   },
   "scripts": {
-    "test": "standard && tape test/test.js"
+    "test": "standard && tape test/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/node_modules/sub-module/bar/index.js
+++ b/test/node_modules/sub-module/bar/index.js
@@ -1,0 +1,1 @@
+module.exports = 'sub-module/bar/index.js'

--- a/test/node_modules/sub-module/conflict.js
+++ b/test/node_modules/sub-module/conflict.js
@@ -1,0 +1,1 @@
+module.exports = 'sub-module/conflict.js'

--- a/test/node_modules/sub-module/conflict/index.js
+++ b/test/node_modules/sub-module/conflict/index.js
@@ -1,0 +1,1 @@
+module.exports = 'sub-module/conflict/index.js'

--- a/test/node_modules/sub-module/foo.js
+++ b/test/node_modules/sub-module/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'sub-module/foo.js'

--- a/test/node_modules/sub-module/index.js
+++ b/test/node_modules/sub-module/index.js
@@ -1,0 +1,1 @@
+module.exports = 'sub-module/index.js'

--- a/test/sub-module.js
+++ b/test/sub-module.js
@@ -1,0 +1,84 @@
+'use strict'
+
+var test = require('tape')
+var Hook = require('../')
+
+test('require(\'sub-module/foo\') => sub-module/foo.js', function (t) {
+  t.plan(3)
+
+  var hook = Hook(['sub-module/foo'], function (exports, name, basedir) {
+    t.equal(name, 'sub-module/foo')
+    return exports
+  })
+
+  t.on('end', function () {
+    hook.unhook()
+  })
+
+  t.equal(require('./node_modules/sub-module'), 'sub-module/index.js')
+  t.equal(require('./node_modules/sub-module/foo'), 'sub-module/foo.js')
+})
+
+test('require(\'sub-module/bar\') => sub-module/bar/index.js', function (t) {
+  t.plan(3)
+
+  var hook = Hook(['sub-module/bar'], function (exports, name, basedir) {
+    t.equal(name, 'sub-module/bar')
+    return exports
+  })
+
+  t.on('end', function () {
+    hook.unhook()
+  })
+
+  t.equal(require('./node_modules/sub-module'), 'sub-module/index.js')
+  t.equal(require('./node_modules/sub-module/bar'), 'sub-module/bar/index.js')
+})
+
+test('require(\'sub-module/bar/../bar\') => sub-module/bar/index.js', function (t) {
+  t.plan(3)
+
+  var hook = Hook(['sub-module/bar'], function (exports, name, basedir) {
+    t.equal(name, 'sub-module/bar')
+    return exports
+  })
+
+  t.on('end', function () {
+    hook.unhook()
+  })
+
+  t.equal(require('./node_modules/sub-module'), 'sub-module/index.js')
+  t.equal(require('./node_modules/sub-module/bar/../bar'), 'sub-module/bar/index.js')
+})
+
+test('require(\'sub-module/conflict\') => sub-module/conflict.js', function (t) {
+  t.plan(3)
+
+  var hook = Hook(['sub-module/conflict'], function (exports, name, basedir) {
+    t.equal(name, 'sub-module/conflict')
+    return exports
+  })
+
+  t.on('end', function () {
+    hook.unhook()
+  })
+
+  t.equal(require('./node_modules/sub-module'), 'sub-module/index.js')
+  t.equal(require('./node_modules/sub-module/conflict'), 'sub-module/conflict.js')
+})
+
+test('require(\'sub-module/conflict/index.js\') => sub-module/conflict/index.js', function (t) {
+  t.plan(3)
+
+  var hook = Hook(['sub-module/conflict'], function (exports, name, basedir) {
+    t.equal(name, 'sub-module/conflict')
+    return exports
+  })
+
+  t.on('end', function () {
+    hook.unhook()
+  })
+
+  t.equal(require('./node_modules/sub-module'), 'sub-module/index.js')
+  t.equal(require('./node_modules/sub-module/conflict/index.js'), 'sub-module/conflict/index.js')
+})


### PR DESCRIPTION
This is required in order to support this use-case elastic/apm-agent-nodejs#913

~~Depends on #20~~

~~While creating this PR I added a lot of debug statements that I submitted as a separate PR: elastic/require-in-the-middle#20~~
~~I could make another PR without those changes, but thought it was good to have, so for now I've left them in.~~