### PR TITLE
perf: store the cache in a Map instead of an Object

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function Hook (modules, options, onrequire) {
     return
   }
 
-  this.cache = {}
+  this.cache = new Map()
   this._unhooked = false
   this._origRequire = Module.prototype.require
 
@@ -55,9 +55,9 @@ function Hook (modules, options, onrequire) {
     debug('processing %s module require(\'%s\'): %s', core === true ? 'core' : 'non-core', request, filename)
 
     // return known patched modules immediately
-    if (Object.prototype.hasOwnProperty.call(self.cache, filename) === true) {
+    if (self.cache.has(filename) === true) {
       debug('returning already patched cached module: %s', filename)
-      return self.cache[filename]
+      return self.cache.get(filename)
     }
 
     // Check if this module has a patcher in-progress already.
@@ -131,16 +131,16 @@ function Hook (modules, options, onrequire) {
     }
 
     // only call onrequire the first time a module is loaded
-    if (Object.prototype.hasOwnProperty.call(self.cache, filename) === false) {
+    if (self.cache.has(filename) === false) {
       // ensure that the cache entry is assigned a value before calling
       // onrequire, in case calling onrequire requires the same module.
-      self.cache[filename] = exports
+      self.cache.set(filename, exports)
       debug('calling require hook: %s', moduleName)
-      self.cache[filename] = onrequire(exports, moduleName, basedir)
+      self.cache.set(filename, onrequire(exports, moduleName, basedir))
     }
 
     debug('returning module: %s', moduleName)
-    return self.cache[filename]
+    return self.cache.get(filename)
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -48,8 +48,8 @@ test('all modules', function (t) {
   t.equal(http.foo, 1)
   t.equal(net.foo, 2)
   t.equal(require('http').foo, 1)
-  t.deepEqual(hook.cache['http'], http)
-  t.deepEqual(hook.cache['net'], net)
+  t.deepEqual(hook.cache.get('http'), http)
+  t.deepEqual(hook.cache.get('net'), net)
   t.equal(n, 3)
 })
 
@@ -99,17 +99,17 @@ test('cache', function (t) {
     hook.unhook()
   })
 
-  t.deepEqual(hook.cache, {})
+  t.deepEqual(Array.from(hook.cache.keys()), [])
   t.equal(require('child_process').foo, 1)
 
-  t.deepEqual(Object.keys(hook.cache), ['child_process'])
+  t.deepEqual(Array.from(hook.cache.keys()), ['child_process'])
   t.equal(require('child_process').foo, 1)
 
-  delete hook.cache['child_process']
-  t.deepEqual(hook.cache, {})
+  hook.cache.delete('child_process')
+  t.deepEqual(Array.from(hook.cache.keys()), [])
 
   t.equal(require('child_process').foo, 2)
-  t.deepEqual(Object.keys(hook.cache), ['child_process'])
+  t.deepEqual(Array.from(hook.cache.keys()), ['child_process'])
 
   t.end()
 })


### PR DESCRIPTION
BREAKING CHANGE: The API of the public `.cache` property changes.