### PR TITLE
Revert "fix: support builtin core modules that contain slashes (#28)"

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@ const parse = require('module-details-from-path')
 
 module.exports = Hook
 
-const builtins = Module.builtinModules
-
 // 'foo/bar.js' or 'foo/bar/index.js' => 'foo/bar'
 const normalize = /([/\\]index)?(\.js)?$/
 
@@ -51,7 +49,7 @@ function Hook (modules, options, onrequire) {
     }
 
     const filename = Module._resolveFilename(id, this)
-    const core = builtins.includes(filename)
+    const core = filename.includes(path.sep) === false
     let moduleName, basedir
 
     debug('processing %s module require(\'%s\'): %s', core === true ? 'core' : 'non-core', id, filename)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "ipp-printer": "^1.0.0",
     "patterns": "^1.0.3",
     "roundround": "^0.2.0",
-    "semver": "^6.3.0",
     "standard": "^14.3.1",
     "tape": "^4.11.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const test = require('tape')
-const semver = require('semver')
 const Hook = require('../')
 
 // The use of deepEqual as opposed to deepStrictEqual in these test is not
@@ -250,29 +249,3 @@ test('multiple hook.unhook()', function (t) {
   hook2.unhook()
   t.end()
 })
-
-if (semver.lt(process.version, '12.0.0')) {
-  test('builtin core module with slash', function (t) {
-    t.plan(5)
-
-    const name = 'v8/tools/splaytree'
-    let n = 1
-
-    const hook = Hook(function (exports, _name, basedir) {
-      t.equal(_name, name)
-      exports.foo = n++
-      return exports
-    })
-
-    t.on('end', function () {
-      hook.unhook()
-    })
-
-    const exports = require(name)
-
-    t.equal(exports.foo, 1)
-    t.equal(require(name).foo, 1)
-    t.deepEqual(hook.cache.get(name), exports)
-    t.equal(n, 2)
-  })
-}


### PR DESCRIPTION
This reverts commit 0bc8510a828f1787199d9cb96608e532083dc327.

The `module.builtinModules` wasn't included in early versions of Node.js 6 and 8 (pre v8.10.0 and pre v6.13.1). Since we want to retain support for those early versions, we'll revert this commit and reintroduce it in a major release