### PR TITLE
fix: support builtin core modules that contain slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,16 @@ const parse = require('module-details-from-path')
 
 module.exports = Hook
 
+const builtins = Module.builtinModules
+
+const isCore = builtins
+  ? (filename) => builtins.includes(filename)
+  // Fallback in case `builtins` isn't available in the current Node.js
+  // version. This isn't as acurate, as some core modules contain slashes, but
+  // all modern versions of Node.js supports `buildins`, so it shouldn't affect
+  // many people.
+  : (filename) => filename.includes(path.sep) === false
+
 // 'foo/bar.js' or 'foo/bar/index.js' => 'foo/bar'
 const normalize = /([/\\]index)?(\.js)?$/
 
@@ -49,7 +59,7 @@ function Hook (modules, options, onrequire) {
     }
 
     const filename = Module._resolveFilename(id, this)
-    const core = filename.includes(path.sep) === false
+    const core = isCore(filename)
     let moduleName, basedir
 
     debug('processing %s module require(\'%s\'): %s', core === true ? 'core' : 'non-core', id, filename)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ipp-printer": "^1.0.0",
     "patterns": "^1.0.3",
     "roundround": "^0.2.0",
+    "semver": "^6.3.0",
     "standard": "^14.3.1",
     "tape": "^4.11.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const test = require('tape')
+const semver = require('semver')
+const Module = require('module')
 const Hook = require('../')
 
 // The use of deepEqual as opposed to deepStrictEqual in these test is not
@@ -249,3 +251,29 @@ test('multiple hook.unhook()', function (t) {
   hook2.unhook()
   t.end()
 })
+
+if (semver.lt(process.version, '12.0.0') && Module.builtinModules) {
+  test('builtin core module with slash', function (t) {
+    t.plan(5)
+
+    const name = 'v8/tools/splaytree'
+    let n = 1
+
+    const hook = Hook(function (exports, _name, basedir) {
+      t.equal(_name, name)
+      exports.foo = n++
+      return exports
+    })
+
+    t.on('end', function () {
+      hook.unhook()
+    })
+
+    const exports = require(name)
+
+    t.equal(exports.foo, 1)
+    t.equal(require(name).foo, 1)
+    t.deepEqual(hook.cache.get(name), exports)
+    t.equal(n, 2)
+  })
+}


### PR DESCRIPTION
This was first introduced via #28, but was reverted again in #32 due to issues with early Node.js versions. This commit includes a fix for the issue introduced in #28.