### PR TITLE
Add typedefs for use with TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+declare module "require-in-the-middle" {
+  interface Hook {
+    unhook(): void
+  }
+
+  function Hook<Module>(
+    modules: string[],
+    onrequire: (exports: Module, name: string, basedir: string) => Module
+  ): Hook
+
+  function Hook<Module>(
+    modules: string[],
+    options: { internals: boolean },
+    onrequire: (exports: Module, name: string, basedir: string) => Module
+  ): Hook
+
+  export = Hook
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "standard": "^14.3.1",
     "tape": "^4.11.0"
   },
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard && tape test/*.js"
   },


### PR DESCRIPTION
Hello there, it's your friends from AppSignal! 👋  

We are using `require-in-the-middle` in our own module `@appsignal/nodejs`. Thank you for making it! I am a TypeScript user, however, and the module doesn't currently include a typedef for TypeScript users, so this PR adds one of those. If you'd prefer to not add it to this repo, I'd be happy to submit this at DefinitelyTyped instead.