### PR TITLE
perf: 6x faster isCore() by replacing the frozen Array with a Set

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const parse = require('module-details-from-path')
 
 module.exports = Hook
 
-const builtins = Module.builtinModules
+const builtins = Module.builtinModules && new Set(Module.builtinModules)
 
 const isCore = builtins
-  ? (filename) => builtins.includes(filename)
+  ? (filename) => builtins.has(filename)
   // Fallback in case `builtins` isn't available in the current Node.js
   // version. This isn't as acurate, as some core modules contain slashes, but
   // all modern versions of Node.js supports `buildins`, so it shouldn't affect


### PR DESCRIPTION
I'm digging into performance issues with pm2 and finally find this repo in which the `Hook._require.Module.require` consumes 1.5ms per `require` call even when the `filename` is already required. I managed to use this patch to reduce 30%+ cputime on each `require()`. Hope it's useful to you!

The `isCore()` function contributes the most to it. [This gist](https://gist.github.com/harttle/78d6aa40097cc1819fd7ba63c9ce1cd6) shows the performance differences between `Module.builtinModules`, normal `Array`, frozen `Array` and `Set`, and following is the result on my MacBook Pro (Catalina, Intel Core i5, 8G memory), which shows the `Set` is 6x faster than `Module.builtinModules.includes()`:

```
Module.builtinModules	 3826550n
modules array		 1219539n 	 -68.00%
fronzen array		 4099637n 	 +7.00%
set			 462133n 	 -87.00%
```

Both Node.js 8 (replace Performance Timing with Date.now()), Node.js 10 and Node.js 12 behave similarly.