### PR TITLE
feat: support 'node:'-prefixed core modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,8 @@ jobs:
   test-vers:
     strategy:
       matrix:
-        node: ['6.0', '6', '8.0', '8', '10.0', '10', '12.0', '12', '14.0', '14', '16.0', '16', '18.0', '18']
+        # Cannot test with 6.0 because `npm install` fails.
+        node: ['6', '8.0', '8', '10.0', '10', '12.0', '12', '14.0', '14', '16.0', '16', '18.0', '18']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test-vers:
     strategy:
       matrix:
-        node: ['8.0', '8', '10.0', '10', '12.0', '12', '14.0', '14', '15']
+        node: ['6.0', '6', '8.0', '8', '10.0', '10', '12.0', '12', '14.0', '14', '16.0', '16', '18.0', '18']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/.vscode

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# require-in-the-middle changelog
+
+## Unreleased
+
+- Add support for hooking into the require of Node core modules prefixed with
+  'node:', e.g. `require('node:http')`. See https://nodejs.org/api/modules.html#core-modules
+  https://github.com/elastic/require-in-the-middle/pull/53
+
+## v5.1.0
+
+- Add support for hooking into require of absolute paths.
+  https://github.com/elastic/require-in-the-middle/issues/43
+
+## earlier versions
+
+Use the [source](https://github.com/elastic/require-in-the-middle/commits/), Luke.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "module-details-from-path": "^1.0.3",
-    "resolve": "^1.12.0"
+    "resolve": "^1.22.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
Since v16.0.0, v14.18.0 node has supported a 'node:'-prefix on
require() of core modules. They typically are an alias for unprefixed
builtin modules, e.g. 'http' and 'node:http' yield the same module.
However, new core modules may be added only with the prefix, e.g.
'node:test' added in node v18.0.0.
https://nodejs.org/api/modules.html#core-modules

This change adds support for a require-in-the-middle hook to capture
the node-prefixed aliases. I.e. `Hook(['http', ...], onRequire)` will
hook into `require('node:http')` and `require('http')`.

Refs: https://github.com/elastic/apm-agent-nodejs/issues/2816

----

@astorm Would you like to review this?  I'll get a draft PR for https://github.com/elastic/apm-agent-nodejs/issues/2816 as well that includes a test case of instrumenting `require('node:http')` once we have a release of this the APM agent can upgrade to.
