### PR TITLE
Support require cache invalidation

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,8 @@ function Hook (modules, options, onrequire) {
     debug('processing %s module require(\'%s\'): %s', core === true ? 'core' : 'non-core', id, filename)
 
     // return known patched modules immediately
-    if (self.cache.has(filename) === true) {
+    const customModuleRemovedFromOriginCache = !core && typeof require.cache[require.resolve(filename)] === 'undefined'
+    if (self.cache.has(filename) === true && customModuleRemovedFromOriginCache === false) {
       debug('returning already patched cached module: %s', filename)
       return self.cache.get(filename)
     }
@@ -167,7 +168,7 @@ function Hook (modules, options, onrequire) {
     }
 
     // only call onrequire the first time a module is loaded
-    if (self.cache.has(filename) === false) {
+    if (self.cache.has(filename) === false || customModuleRemovedFromOriginCache === true) {
       // ensure that the cache entry is assigned a value before calling
       // onrequire, in case calling onrequire requires the same module.
       self.cache.set(filename, exports)

--- a/test/test.js
+++ b/test/test.js
@@ -117,6 +117,50 @@ test('cache', function (t) {
   t.end()
 })
 
+test('removed custom module from origin require cache', function (t) {
+  let n = 0
+
+  const hook = Hook(['standard'], function (exports, name, basedir) {
+    exports.foo = ++n
+    return exports
+  })
+
+  t.on('end', function () {
+    hook.unhook()
+  })
+
+  t.equal(require('standard').foo, 1)
+  t.equal(require('standard').foo, 1)
+
+  delete require.cache[require.resolve('standard')]
+
+  t.equal(require('standard').foo, 2)
+
+  t.end()
+})
+
+test('removed core module from origin require cache', function (t) {
+  let n = 0
+
+  const hook = Hook(['child_process'], function (exports, name, basedir) {
+    exports.foo = ++n
+    return exports
+  })
+
+  t.on('end', function () {
+    hook.unhook()
+  })
+
+  t.equal(require('child_process').foo, 1)
+  t.equal(require('child_process').foo, 1)
+
+  delete require.cache[require.resolve('child_process')]
+
+  t.equal(require('child_process').foo, 1)
+
+  t.end()
+})
+
 test('replacement value', function (t) {
   const replacement = {}
 


### PR DESCRIPTION
Hi,

Using opentelemetry instrumenter that uses this project prevents us to correctly invalidate require cache because require-in-the-middle bypass it using its own cache of patched modules.

This PR ensures the origin cache has the same file as ours, and if not we require and patch the module.