### PR TITLE
feat: support deferring to the underlying 'require' implementation if Module._resolveFilename fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # require-in-the-middle changelog
 
+## Unreleased
+
+- If resolving the filename for a `require(...)` fails, defer to the wrapped
+  require implementation rather than failing right away. This allows a
+  possibly-monkey-patched `require` to do its own special thing.
+  https://github.com/elastic/require-in-the-middle/pull/59
+
 ## v6.0.0
 
 - Drop Node.js 6 support. New minimum supported Node.js version is 8.6.0.

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function Hook (modules, options, onrequire) {
         // For example the Azure Functions Node.js worker module does this,
         // where `@azure/functions-core` resolves to an internal object.
         // https://github.com/Azure/azure-functions-nodejs-worker/blob/v3.5.2/src/setupCoreModule.ts#L46-L54
-        debug(`Module._resolveFilename('${id}') threw ${JSON.stringify(resolveErr.message)}, calling original Module.require`)
+        debug('Module._resolveFilename('%s') threw %j, calling original Module.require', id, resolveErr.message)
         return self._origRequire.apply(this, arguments)
       }
     }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path')
 const Module = require('module')
 const resolve = require('resolve')
 const debug = require('debug')('require-in-the-middle')
-const parse = require('module-details-from-path')
+const moduleDetailsFromPath = require('module-details-from-path')
 
 module.exports = Hook
 
@@ -78,7 +78,20 @@ function Hook (modules, options, onrequire) {
         }
       }
     } else {
-      filename = Module._resolveFilename(id, this)
+      try {
+        filename = Module._resolveFilename(id, this)
+      } catch (resolveErr) {
+        // If someone *else* monkey-patches before this monkey-patch, then that
+        // code might expect `require(someId)` to get through so it can be
+        // handled, even if `someId` cannot be resolved to a filename. In this
+        // case, instead of throwing we defer to the underlying `require`.
+        //
+        // For example the Azure Functions Node.js worker module does this,
+        // where `@azure/functions-core` resolves to an internal object.
+        // https://github.com/Azure/azure-functions-nodejs-worker/blob/v3.5.2/src/setupCoreModule.ts#L46-L54
+        debug(`Module._resolveFilename('${id}') threw ${JSON.stringify(resolveErr.message)}, calling original Module.require`)
+        return self._origRequire.apply(this, arguments)
+      }
     }
 
     let moduleName, basedir
@@ -122,8 +135,8 @@ function Hook (modules, options, onrequire) {
       moduleName = parsedPath.name
       basedir = parsedPath.dir
     } else {
-      const stat = parse(filename)
-      if (stat === undefined) {
+      const stat = moduleDetailsFromPath(filename)
+      if (!stat) {
         debug('could not parse filename: %s', filename)
         return exports // abort if filename could not be parsed
       }

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function Hook (modules, options, onrequire) {
         // For example the Azure Functions Node.js worker module does this,
         // where `@azure/functions-core` resolves to an internal object.
         // https://github.com/Azure/azure-functions-nodejs-worker/blob/v3.5.2/src/setupCoreModule.ts#L46-L54
-        debug('Module._resolveFilename('%s') threw %j, calling original Module.require', id, resolveErr.message)
+        debug('Module._resolveFilename("%s") threw %j, calling original Module.require', id, resolveErr.message)
         return self._origRequire.apply(this, arguments)
       }
     }

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function Hook (modules, options, onrequire) {
       basedir = parsedPath.dir
     } else {
       const stat = moduleDetailsFromPath(filename)
-      if (!stat) {
+      if (stat === undefined) {
         debug('could not parse filename: %s', filename)
         return exports // abort if filename could not be parsed
       }

--- a/test/already-monkey-patched-require.test.js
+++ b/test/already-monkey-patched-require.test.js
@@ -28,12 +28,18 @@ test('already monkey-patched require', function (t) {
     exports.foo = 1
     return exports
   })
-  t.equal(require('http').foo, 1)
+  t.equal(require('http').foo, 1, 'normal hooking still works')
 
   const fnCore = require('@azure/functions-core')
-  t.ok(fnCore)
+  t.ok(fnCore, 'requiring monkey-patched-in module works')
   t.equal(fnCore.version, '1.0.0')
   t.equal(typeof fnCore.registerHook, 'function')
+
+  t.throws(
+    () => require('this-package-does-not-exist'),
+    { code: 'MODULE_NOT_FOUND' },
+    'a failing `require(...)` can still throw as expected'
+  )
 
   hook.unhook()
   t.end()

--- a/test/already-monkey-patched-require.test.js
+++ b/test/already-monkey-patched-require.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const Module = require('module')
+const test = require('tape')
+
+const Hook = require('../')
+
+// If a monkey-patch of `require` is already in place that attempts to resolve
+// non-existant modules (e.g. '@azure/functions-core' in this case), and *then*
+// require-in-the-middle is called; then ritm should fallback to the other
+// require implementation when it fails to resolve the module path.
+test('already monkey-patched require', function (t) {
+  // Adapted from https://github.com/Azure/azure-functions-nodejs-worker/blob/v3.5.2/src/setupCoreModule.ts#L46-L54
+  Module.prototype.require = new Proxy(Module.prototype.require, {
+    apply (target, thisArg, argArray) {
+      if (argArray[0] === '@azure/functions-core') {
+        return {
+          version: '1.0.0',
+          registerHook: () => {}
+        }
+      } else {
+        return Reflect.apply(target, thisArg, argArray)
+      }
+    }
+  })
+
+  const hook = Hook(['http'], function onRequire (exports, name, basedir) {
+    exports.foo = 1
+    return exports
+  })
+  t.equal(require('http').foo, 1)
+
+  const fnCore = require('@azure/functions-core')
+  t.ok(fnCore)
+  t.equal(fnCore.version, '1.0.0')
+  t.equal(typeof fnCore.registerHook, 'function')
+
+  hook.unhook()
+  t.end()
+})


### PR DESCRIPTION
There might be an already monkey-patched 'require' that knows how to
resolve a special identifier. This is needed to use
require-in-the-middle with 'azure-functions-nodejs-worker', which
patches 'require' to support `require('@azure/functions-core')`.
