### PR TITLE
feat!: use `require.cache` for caching patched exports for non-core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /node_modules
 /.vscode
+/tmp
+*.example.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - If resolving the filename for a `require(...)` fails, defer to the wrapped
   require implementation rather than failing right away. This allows a
   possibly-monkey-patched `require` to do its own special thing.
-  https://github.com/elastic/require-in-the-middle/pull/59
+  (https://github.com/elastic/require-in-the-middle/pull/59)
 
 ## v6.0.0
 
@@ -31,12 +31,12 @@
 
 - Add support for hooking into the require of Node core modules prefixed with
   'node:', e.g. `require('node:http')`. See https://nodejs.org/api/modules.html#core-modules
-  https://github.com/elastic/require-in-the-middle/pull/53
+  (https://github.com/elastic/require-in-the-middle/pull/53)
 
 ## v5.1.0
 
 - Add support for hooking into require of absolute paths.
-  https://github.com/elastic/require-in-the-middle/issues/43
+  (https://github.com/elastic/require-in-the-middle/issues/43)
 
 ## earlier versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Use the Node.js `require.cache` for caching the exports returned from a
+  Hook's `onrequire`. This allows users to delete entries from `require.cache`
+  to trigger a re-load (and re-run of the hook's `onrequire`) of a module the
+  next time it is required -- as mentioned at
+  https://nodejs.org/docs/latest/api/all.html#all_modules_requirecache
+  (https://github.com/elastic/require-in-the-middle/issues/61)
+
+- (SEMVER-MAJOR) Remove the `hook.cache` field. In earlier versions this was
+  available and some tests used it. However it was never a documented field.
+
 - If resolving the filename for a `require(...)` fails, defer to the wrapped
   require implementation rather than failing right away. This allows a
   possibly-monkey-patched `require` to do its own special thing.

--- a/test/require-cache-inval.js
+++ b/test/require-cache-inval.js
@@ -1,0 +1,66 @@
+'use strict'
+
+// Test support for triggering a reload/re-patch of a module by deleting it
+// from `require.cache`.
+// (https://github.com/elastic/require-in-the-middle/pull/63)
+
+const test = require('tape')
+
+const Hook = require('../')
+
+test('reload/re-patch via `delete require.cache[name]`', function (t) {
+  let numOnRequireCalls = 0
+  const hook = Hook(['semver'], function (exports, name, basedir) {
+    numOnRequireCalls++
+    return exports
+  })
+  const semver1 = require('semver')
+  t.equal(numOnRequireCalls, 1)
+  const semver2 = require('semver')
+  t.equal(numOnRequireCalls, 1)
+  t.ok(semver2 === semver1)
+
+  delete require.cache[require.resolve('semver')]
+  const semver3 = require('semver')
+  t.equal(numOnRequireCalls, 2, 'onrequire was called again')
+  t.ok(semver3 !== semver1)
+
+  t.end()
+  hook.unhook()
+})
+
+// An originating issue that led to this RITM functionality was
+// https://github.com/open-telemetry/opentelemetry-js/issues/3655
+// where RITM didn't work with 'stealthy-require', which swaps `Module` values
+// from `require.cache` in and out. This test case tests that.
+test('stealty-require swap in/out Module values from require.cache', function (t) {
+  let numOnRequireCalls = 0
+  const hook = Hook(['semver'], function (exports, name, basedir) {
+    numOnRequireCalls++
+    return exports
+  })
+  const semver1 = require('semver')
+  t.equal(numOnRequireCalls, 1)
+  t.ok(semver1.parse)
+
+  // Swap out cached 'semver' Module.
+  const semverPath = require.resolve('semver')
+  const mod = require.cache[semverPath]
+  delete require.cache[semverPath]
+
+  const semver2 = require('semver')
+  t.equal(numOnRequireCalls, 2, 'onrequire was called again after swap out')
+  t.ok(semver2.parse)
+  t.ok(semver2 !== semver1)
+
+  // Swap 'semver' Module cache back in.
+  require.cache[semverPath] = mod
+
+  const semver3 = require('semver')
+  t.equal(numOnRequireCalls, 2, 'onrequire was *not* called again after swap in')
+  t.ok(semver3.parse)
+  t.ok(semver3 === semver1)
+
+  t.end()
+  hook.unhook()
+})


### PR DESCRIPTION
This allows a user to delete from `require.cache` to trigger a re-load of a module (and a re-run of the hook's `onrequire`) on next `require()`.

This also removes the `.cache` field from the Hook object. It was never documented, but it wasn't prefixed with `_` to hint at being private. As well, some tests used it, which might have given the impression it could be used externally. I'm calling this a semver-major change to give a heads up to users that might have been using it.

Fixes: #61

# checklist

- [ ] add a test case for this
- [ ] possibly get some reviews
- [ ] run through apm-agent-nodejs tests
