### PR TITLE
feat: add TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.0",
   "description": "Module to hook into the Node.js require function",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "dependencies": {
     "debug": "^4.1.1",
     "module-details-from-path": "^1.0.3",
@@ -42,7 +43,9 @@
     "module",
     "load"
   ],
-  "files": [],
+  "files": [
+    "types"
+  ],
   "author": "Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)",
   "license": "MIT",
   "bugs": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,12 @@
+export interface HookOptions {
+  internals?: boolean;
+}
+
+export type OnRequireFn = <T>(exports: T, name: string, basedir?: string) => T;
+
+export class Hook {
+  constructor(modules: string[] | null, options: HookOptions | null, onrequire: OnRequireFn);
+  constructor(modules: string[] | null, onrequire: OnRequireFn);
+  constructor(onrequire: OnRequireFn);
+  unhook(): void;
+}


### PR DESCRIPTION
These should be considered experimental. I'm not confident in my
TypeScript typing.

These are based on the types from `@opentelemetry/instrumentation`: https://github.com/open-telemetry/opentelemetry-js/blob/v1.11.0/experimental/packages/opentelemetry-instrumentation/src/platform/node/require-in-the-middle.d.ts