### PR TITLE
Cache exports in additional code paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,6 +236,7 @@ function Hook (modules, options, onrequire) {
           res = resolve.sync(moduleName, { basedir })
         } catch (e) {
           debug('could not resolve module: %s', moduleName)
+          self._cache.set(filename, exports, core)
           return exports // abort if module could not be resolved (e.g. no main in package.json and no index.js file)
         }
 
@@ -247,6 +248,7 @@ function Hook (modules, options, onrequire) {
             debug('preparing to process require of internal file: %s', moduleName)
           } else {
             debug('ignoring require of non-main module file: %s', res)
+            self._cache.set(filename, exports, core)
             return exports // abort if not main module file
           }
         }


### PR DESCRIPTION
Makes the change proposed in #75.

Note that there are a few other early-returns of `exports` where we could in theory use the exports cache as well. However, those all occur prior to the call to `resolve.sync(...)`, which AFAICT is the slowest part of this code since that actually does a lot of filesystem operations. Everything before that point should be fast code that doesn't do any async filesystem/etc. operations, which means that the benefits to caching in that case is most likely negligible.