### PR TITLE
Handle mapped exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,10 +225,10 @@ function Hook (modules, options, onrequire) {
       // moduleName = 'foo'
       // fullModuleName = 'foo/bar'
       if (hasWhitelist === true && modules.includes(moduleName) === false) {
-        if (modules.includes(fullModuleName) === false) return exports // abort if module name isn't on whitelist
+        if (isWhitelistedMappedModule({ modules, fullModuleName }) === false) return exports // abort if module name isn't on whitelist
 
         // if we get to this point, it means that we're requiring a whitelisted sub-module
-        moduleName = fullModuleName
+        moduleName = normalizeModuleName(fullModuleName)
       } else {
         // figure out if this is the main module file, or a file inside the module
         let res
@@ -280,4 +280,35 @@ Hook.prototype.unhook = function () {
 function resolveModuleName (stat) {
   const normalizedPath = path.sep !== '/' ? stat.path.split(path.sep).join('/') : stat.path
   return path.posix.join(stat.name, normalizedPath).replace(normalize, '')
+}
+
+/**
+ * Determines if a module is included in the allow list regardless of file
+ * extension.
+ *
+ * @param {string[]} modules The list of module names that are allowed to be
+ * hooked by the current hook process.
+ * @param {string} fullModuleName The fully resolved module name that may or
+ * may not end with a file extension.
+ *
+ * @returns {boolean}
+ */
+function isWhitelistedMappedModule ({ modules, fullModuleName }) {
+  return modules.includes(normalizeModuleName(fullModuleName))
+}
+
+/**
+ * Remove any file extension from a module name that may have been added by
+ * resolving a mapped export to the correct source file.
+ *
+ * @example
+ * const name = normalizeModuleName('@foo/bar/baz.cjs')
+ * console.log(name) // '@foo/bar/baz'
+ *
+ * @param {string} input The module name to normalize.
+ *
+ * @returns {string}
+ */
+function normalizeModuleName (input) {
+  return input.replace(/(\.(js|cjs))$/, '')
 }

--- a/test/mapped-exports.js
+++ b/test/mapped-exports.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const test = require('tape')
+const { Hook } = require('../')
+
+test('handles mapped exports', function (t) {
+  t.plan(2)
+
+  const hook = new Hook(['mapped-exports/foo'], function (exports, name) {
+    t.equal(name, 'mapped-exports/foo')
+    const answer = exports.answer
+    exports.answer = function wrappedAnswer () {
+      return 'wrapped-' + answer()
+    }
+    return exports
+  })
+
+  t.on('end', hook.unhook)
+
+  const foo = require('mapped-exports/foo')
+  t.equal(foo.answer(), 'wrapped-42')
+})

--- a/test/mapped-exports.js
+++ b/test/mapped-exports.js
@@ -1,9 +1,13 @@
 'use strict'
 
+const semver = require('semver')
 const test = require('tape')
 const { Hook } = require('../')
 
-test('handles mapped exports: mapped-exports/foo', function (t) {
+// Mapped export tests require Node.js >=12.17.0 for "exports" support in package.json.
+const nodeSupportsExports = semver.lt(process.version, '12.17.0')
+
+test('handles mapped exports: mapped-exports/foo', { skip: nodeSupportsExports }, function (t) {
   t.plan(2)
 
   const hook = new Hook(['mapped-exports/foo'], function (exports, name) {
@@ -21,7 +25,7 @@ test('handles mapped exports: mapped-exports/foo', function (t) {
   hook.unhook()
 })
 
-test('handles mapped exports: mapped-exports/bar', function (t) {
+test('handles mapped exports: mapped-exports/bar', { skip: nodeSupportsExports }, function (t) {
   t.plan(2)
 
   const hook = new Hook(['mapped-exports/bar'], function (exports, name) {

--- a/test/mapped-exports.js
+++ b/test/mapped-exports.js
@@ -3,7 +3,7 @@
 const test = require('tape')
 const { Hook } = require('../')
 
-test('handles mapped exports', function (t) {
+test('handles mapped exports: mapped-exports/foo', function (t) {
   t.plan(2)
 
   const hook = new Hook(['mapped-exports/foo'], function (exports, name) {
@@ -15,8 +15,26 @@ test('handles mapped exports', function (t) {
     return exports
   })
 
-  t.on('end', hook.unhook)
-
   const foo = require('mapped-exports/foo')
   t.equal(foo.answer(), 'wrapped-42')
+
+  hook.unhook()
+})
+
+test('handles mapped exports: mapped-exports/bar', function (t) {
+  t.plan(2)
+
+  const hook = new Hook(['mapped-exports/bar'], function (exports, name) {
+    t.equal(name, 'mapped-exports/bar')
+    const answer = exports.answer
+    exports.answer = function wrappedAnswer () {
+      return 'wrapped-' + answer()
+    }
+    return exports
+  })
+
+  const bar = require('mapped-exports/bar')
+  t.equal(bar.answer(), 'wrapped-42')
+
+  hook.unhook()
 })

--- a/test/node_modules/mapped-exports/dist/cjs/bar.cjs
+++ b/test/node_modules/mapped-exports/dist/cjs/bar.cjs
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  bar: 'bar',
+  answer () {
+    return 42
+  }
+}

--- a/test/node_modules/mapped-exports/dist/esm/bar.js
+++ b/test/node_modules/mapped-exports/dist/esm/bar.js
@@ -1,0 +1,8 @@
+const bar = {
+  bar: 'bar',
+  answer () {
+    return 42
+  }
+}
+
+export default bar

--- a/test/node_modules/mapped-exports/foo.cjs
+++ b/test/node_modules/mapped-exports/foo.cjs
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  foo: 'foo',
+  answer () {
+    return 42
+  }
+}

--- a/test/node_modules/mapped-exports/foo.js
+++ b/test/node_modules/mapped-exports/foo.js
@@ -1,0 +1,8 @@
+const foo = {
+  foo: 'foo',
+  answer () {
+    return 42
+  }
+}
+
+export default foo

--- a/test/node_modules/mapped-exports/index.js
+++ b/test/node_modules/mapped-exports/index.js
@@ -1,0 +1,2 @@
+import foo from './foo.js'
+export default foo

--- a/test/node_modules/mapped-exports/package.json
+++ b/test/node_modules/mapped-exports/package.json
@@ -1,0 +1,13 @@
+{
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js"
+    },
+    "./foo": {
+      "require": "./foo.cjs",
+      "import": "./foo.js"
+    }
+  }
+}

--- a/test/node_modules/mapped-exports/package.json
+++ b/test/node_modules/mapped-exports/package.json
@@ -8,6 +8,10 @@
     "./foo": {
       "require": "./foo.cjs",
       "import": "./foo.js"
+    },
+    "./bar": {
+      "require": "./dist/cjs/bar.cjs",
+      "import": "./dist/esm/bar.js"
     }
   }
 }


### PR DESCRIPTION
This PR fixes an issue with mapped exports. Basically, if a module exports multiple versions of the same source then the commonjs export will end up with a file extension added. When the file extension is added, it breaks the allow list lookup and results in the hook never being applied.