### PR TITLE
Fix hooking parent and sub module with a single hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,12 +224,21 @@ function Hook (modules, options, onrequire) {
       // Ex: require('foo/lib/../bar.js')
       // moduleName = 'foo'
       // fullModuleName = 'foo/bar'
-      const modulesIncludesFullModuleName = hasWhitelist && modules.includes(fullModuleName)
-      if (hasWhitelist === true && (modulesIncludesFullModuleName === true || modules.includes(moduleName) === false)) {
-        if (modulesIncludesFullModuleName === false) return exports // abort if module name isn't on whitelist
-        // if we get to this point, it means that we're requiring a whitelisted sub-module
-        moduleName = fullModuleName
-      } else {
+      let isWhitelistedSubmodule = false
+      if (hasWhitelist) {
+        // abort if module name isn't on whitelist
+        if (!modules.includes(moduleName) && !modules.includes(fullModuleName)) {
+          return exports
+        }
+
+        if (modules.includes(fullModuleName)) {
+          // if we get to this point, it means that we're requiring a whitelisted sub-module
+          moduleName = fullModuleName
+          isWhitelistedSubmodule = true
+        }
+      }
+
+      if (!isWhitelistedSubmodule) {
         // figure out if this is the main module file, or a file inside the module
         let res
         try {

--- a/index.js
+++ b/index.js
@@ -224,9 +224,9 @@ function Hook (modules, options, onrequire) {
       // Ex: require('foo/lib/../bar.js')
       // moduleName = 'foo'
       // fullModuleName = 'foo/bar'
-      if (hasWhitelist === true && modules.includes(moduleName) === false) {
-        if (modules.includes(fullModuleName) === false) return exports // abort if module name isn't on whitelist
-
+      const modulesIncludesFullModuleName = hasWhitelist && modules.includes(fullModuleName)
+      if (hasWhitelist === true && (modulesIncludesFullModuleName === true || modules.includes(moduleName) === false)) {
+        if (modulesIncludesFullModuleName === false) return exports // abort if module name isn't on whitelist
         // if we get to this point, it means that we're requiring a whitelisted sub-module
         moduleName = fullModuleName
       } else {

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ function Hook (modules, options, onrequire) {
           return exports
         }
 
-        if (modules.includes(fullModuleName)) {
+        if (modules.includes(fullModuleName) && moduleName !== fullModuleName) {
           // if we get to this point, it means that we're requiring a whitelisted sub-module
           moduleName = fullModuleName
           isWhitelistedSubmodule = true

--- a/test/sub-module.js
+++ b/test/sub-module.js
@@ -83,3 +83,26 @@ test('require(\'sub-module/conflict/index.js\') => sub-module/conflict/index.js'
   t.equal(require('./node_modules/sub-module'), 'sub-module/index.js')
   t.equal(require('./node_modules/sub-module/conflict/index.js'), 'sub-module/conflict/index.js')
 })
+
+test('require(\'sub-module/foo\') with \'sub-module\'', function (t) {
+  t.plan(5)
+
+  const names = []
+  const hook = new Hook(['sub-module/foo', 'sub-module'], function (exports, name, basedir) {
+    names.push(name)
+    if (name === 'sub-module') {
+      t.equal(exports, 'sub-module/index.js')
+    } else {
+      t.equal(exports, 'sub-module/foo.js')
+    }
+    return name
+  })
+
+  t.on('end', function () {
+    hook.unhook()
+  })
+
+  t.equal(require('./node_modules/sub-module'), 'sub-module')
+  t.equal(require('./node_modules/sub-module/foo'), 'sub-module/foo')
+  t.same(names, ['sub-module', 'sub-module/foo'])
+})


### PR DESCRIPTION
Fix https://github.com/elastic/require-in-the-middle/issues/79

Fix the bug causing a hook used for both a module and some of its sub module to only hook into the parent module. 

```js
new Hook(['sub-module/foo', 'sub-module'], handler)
```