### PR TITLE
Fixes allow listing mapped modules that resolve with an extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,11 +237,12 @@ function Hook (modules, options, onrequire) {
         }
 
         // abort if module name isn't on whitelist
-        if (!modules.includes(moduleName) && !modules.includes(fullModuleName)) {
+        const noExtFullModuleName = fullModuleName.replace(/(.+)(\.(js|cjs))$/, '$1')
+        if (!modules.includes(moduleName) && !modules.includes(noExtFullModuleName)) {
           return exports
         }
 
-        if (modules.includes(fullModuleName) && fullModuleName !== moduleName) {
+        if (modules.includes(noExtFullModuleName) && noExtFullModuleName !== moduleName) {
           // if we get to this point, it means that we're requiring a whitelisted sub-module
           moduleName = fullModuleName
           matchFound = true

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/register": "^7.9.0",
+    "@langchain/core": "0.1.57",
     "ipp-printer": "^1.0.0",
     "patterns": "^1.0.3",
     "roundround": "^0.2.0",

--- a/test/mapped-exports.js
+++ b/test/mapped-exports.js
@@ -42,3 +42,23 @@ test('handles mapped exports: mapped-exports/bar', { skip: nodeSupportsExports }
 
   hook.unhook()
 })
+
+test('handles mapped exports: picks up allow listed resolved module', { skip: nodeSupportsExports }, function (t) {
+  t.plan(2)
+
+  let hookHit = false
+  const hook = new Hook(['@langchain/core/dist/callbacks/manager'], function (exports, name) {
+    t.equal(name, '@langchain/core/dist/callbacks/manager.cjs')
+    exports.BaseCallbackManager.prototype.setHandler = function () {
+      hookHit = true
+    }
+    return exports
+  })
+
+  const { CallbackManager } = require('@langchain/core/callbacks/manager')
+  const manager = new CallbackManager()
+  manager.setHandler(() => {})
+  t.equal(hookHit, true)
+
+  hook.unhook()
+})


### PR DESCRIPTION
PR #82 originally included code to ignore the resolved file extension. This PR restores that functionality.