### PR TITLE
refactor: use core Node.js resolve function if possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const moduleDetailsFromPath = require('module-details-from-path')
 module.exports = Hook
 module.exports.Hook = Hook
 
+let builtinModules // Set<string>
+
 /**
  * Is the given module a "core" module?
  * https://nodejs.org/api/modules.html#core-modules
@@ -26,7 +28,11 @@ if (Module.isBuiltin) { // Added in node v18.6.0, v16.17.0
       return true
     }
 
-    return Module.builtinModules.includes(moduleName)
+    if (builtinModules === undefined) {
+      builtinModules = new Set(Module.builtinModules)
+    }
+
+    return builtinModules.has(moduleName)
   }
 } else {
   const _resolve = require('resolve')

--- a/index.js
+++ b/index.js
@@ -20,7 +20,16 @@ module.exports.Hook = Hook
 let isCore
 if (Module.isBuiltin) { // Added in node v18.6.0, v16.17.0
   isCore = Module.isBuiltin
+} else if (Module.builtinModules) { // Added in node v9.3.0, v8.10.0, v6.13.0
+  isCore = moduleName => {
+    if (moduleName.startsWith('node:')) {
+      return true
+    }
+
+    return Module.builtinModules.includes(moduleName)
+  }
 } else {
+  const _resolve = require('resolve')
   const [major, minor] = process.versions.node.split('.').map(Number)
   if (major === 8 && minor < 8) {
     // For node versions `[8.0, 8.8)` the "http2" module was built-in but
@@ -34,13 +43,13 @@ if (Module.isBuiltin) { // Added in node v18.6.0, v16.17.0
       }
       // Prefer `resolve.core` lookup to `resolve.isCore(moduleName)` because
       // the latter is doing version range matches for every call.
-      return !!resolve.core[moduleName]
+      return !!_resolve.core[moduleName]
     }
   } else {
     isCore = moduleName => {
       // Prefer `resolve.core` lookup to `resolve.isCore(moduleName)` because
       // the latter is doing version range matches for every call.
-      return !!resolve.core[moduleName]
+      return !!_resolve.core[moduleName]
     }
   }
 }


### PR DESCRIPTION
This is a copy of #25 which looks like it was opened before CI tests were added.

I've fixed the original PR to pass on all tested versions.

If we made the minimum supported Node version `>= v8.10.0 | >= v9.3.0` then we could remove `resolve` as a dependency entirely but this would be a breaking change!