### PR TITLE
fix: Bundler issue caused by `require('./package.json')`

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function Hook (modules, options, onrequire) {
 
   if (typeof Module._resolveFilename !== 'function') {
     console.error('Error: Expected Module._resolveFilename to be a function (was: %s) - aborting!', typeof Module._resolveFilename)
-    console.error('Please report this error as an issue related to Node.js %s at %s', process.version, require('./package.json').bugs.url)
+    console.error('Please report this error as an issue related to Node.js %s at https://github.com/nodejs/require-in-the-middle/issues', process.version)
     return
   }
 


### PR DESCRIPTION
- Closes #115

Using `require('./package.json').bugs.url` causes warnings from bundlers when they don't have JSON support enabled.

Even if a bundler does support reading `package.json`, this will result in the entire file being included in the bundle.