### PR TITLE
fix: guard against require.cache being unavailable

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,12 @@ const normalize = /([/\\]index)?(\.js)?$/
 // In some special cases -- e.g. some other `require()` hook swapping out
 // `Module._cache` like `@babel/register` -- a non-core module won't be in
 // `require.cache`. In that case this falls back to caching on the internal Map.
+//
+// `require.cache` itself can also be missing entirely -- e.g. when this
+// package is bundled by a tool like esbuild for an ESM target, the bundler
+// substitutes its own `require` shim (without a `.cache` property) for the
+// real Node.js `require`. This also falls back to the internal Map.
+// https://github.com/nodejs/require-in-the-middle/issues/113
 class ExportsCache {
   constructor () {
     this._localCache = new Map() // <module filename or id> -> <exports>
@@ -63,7 +69,7 @@ class ExportsCache {
   has (filename, isBuiltin) {
     if (this._localCache.has(filename)) {
       return true
-    } else if (!isBuiltin) {
+    } else if (!isBuiltin && require.cache) {
       const mod = require.cache[filename]
       return !!(mod && this._kRitmExports in mod)
     } else {
@@ -75,7 +81,7 @@ class ExportsCache {
     const cachedExports = this._localCache.get(filename)
     if (cachedExports !== undefined) {
       return cachedExports
-    } else if (!isBuiltin) {
+    } else if (!isBuiltin && require.cache) {
       const mod = require.cache[filename]
       return (mod && mod[this._kRitmExports])
     }
@@ -84,7 +90,7 @@ class ExportsCache {
   set (filename, exports, isBuiltin) {
     if (isBuiltin) {
       this._localCache.set(filename, exports)
-    } else if (filename in require.cache) {
+    } else if (require.cache && filename in require.cache) {
       require.cache[filename][this._kRitmExports] = exports
     } else {
       debug('non-core module is unexpectedly not in require.cache: "%s"', filename)

--- a/test/require-cache-undefined.test.js
+++ b/test/require-cache-undefined.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const vm = require('vm')
+const Module = require('module')
+const path = require('path')
+const fs = require('fs')
+const test = require('tape')
+
+// When require-in-the-middle is bundled by a tool like esbuild for an
+// ESM/browser-like target, the top-level `require` binding used inside
+// index.js is not the real Node.js `require` but a bundler-provided shim
+// (e.g. esbuild's `__require` helper). That shim can still resolve real
+// modules, but it has no `.cache` property, since only the real Node.js
+// `require` has one.
+//
+// This test loads index.js's own source with such a shim substituted in for
+// `require`, to reproduce that environment without needing an actual
+// bundler in devDependencies.
+// https://github.com/nodejs/require-in-the-middle/issues/113
+test('does not throw when require.cache is missing (e.g. bundler shim)', function (t) {
+  const indexPath = path.resolve(__dirname, '..', 'index.js')
+  const src = fs.readFileSync(indexPath, 'utf8')
+  const script = new vm.Script(Module.wrap(src), { filename: indexPath })
+  const fn = script.runInThisContext()
+
+  const fakeModule = { exports: {} }
+  // A require shim with no `.cache` property, same shape as esbuild's.
+  const fakeRequire = Object.assign(
+    (id) => require(id),
+    { resolve: require.resolve }
+  )
+
+  fn.call(fakeModule.exports, fakeModule.exports, fakeRequire, fakeModule, indexPath, path.dirname(indexPath))
+
+  const { Hook } = fakeModule.exports
+
+  let numOnRequireCalls = 0
+  const hook = new Hook(['semver'], function (exports) {
+    numOnRequireCalls++
+    return exports
+  })
+
+  try {
+    t.doesNotThrow(function () {
+      require('semver')
+    })
+  } finally {
+    hook.unhook()
+  }
+
+  t.equal(numOnRequireCalls, 1)
+  t.end()
+})


### PR DESCRIPTION
## Summary

`ExportsCache`'s `has()`/`get()`/`set()` methods assume `require.cache` always exists as an object. When this package is bundled by a tool like esbuild for an ESM target, the bundler substitutes its own `require` shim (no `.cache` property) for the real Node.js `require`. Indexing into `require.cache` then throws `Cannot read properties of undefined (reading '...')`, instead of falling back to the internal Map the class already uses when a module is missing from `require.cache`.

## Fix

Add a `require.cache` truthiness check alongside the existing `isBuiltin` check in `has()`, `get()`, and `set()`. Falls back to the internal Map when `require.cache` itself is missing, not just when an entry is missing from it. No change in normal Node.js environments, where `require.cache` is always present.

Known limitation, not introduced by this fix: when `require.cache` is unavailable, non-core modules are cached in the internal Map instead. The existing `delete require.cache[...]`-to-force-a-reload trick (see `test/require-cache-inval.js`) doesn't work in that environment, since the internal Map has no external invalidation hook.

## Test

Added `test/require-cache-undefined.test.js`. Uses `vm` + `Module.wrap()` to load `index.js`'s own source with a `require` shim that has no `.cache` property, matching esbuild's shim shape - no need to add esbuild as a dependency.

- Test reproduces the crash on unmodified `index.js`.
- Passes with the fix.
- Full suite (`npm test`: lint + 102 tape tests + babel test) passes.

## Relationship to #121

#121 addresses #120 (webpack replacing `require.resolve`, a broader external-module-resolution problem). This PR is a narrower, independent fix for the `require.cache === undefined` crash in #113 - no overlap in scope.

## Test plan

- [x] Added regression test reproducing the exact crash
- [x] Confirmed regression test fails without the fix
- [x] Full local suite (lint + tape + babel) passes

Fixes #113
